### PR TITLE
Add advanced dashboard and dark mode

### DIFF
--- a/TAILWIND-DEMO.md
+++ b/TAILWIND-DEMO.md
@@ -262,13 +262,21 @@ If you want to speed up development even more, consider these libraries:
 
 ### 4. Interactive Elements
 ```html
-<button class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 
+<button class="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700
                focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50
                disabled:opacity-50 disabled:cursor-not-allowed
                transition-colors">
   Click me
 </button>
 ```
+
+## Advanced Dashboard and Dark Mode
+
+The project now includes an additional **Advanced Dashboard** page demonstrating
+more sophisticated Tailwind components such as server status cards. A dedicated
+dark mode toggle stores the preference in `localStorage` and applies the `dark`
+class on the `<html>` element. Many components include `dark:` variants so the
+interface adapts automatically when toggled.
 
 ## Conclusion
 

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+  ignoreFiles: [/tailwindcss\/lib\/index.js$/],
+};

--- a/src/components/AlertCard.astro
+++ b/src/components/AlertCard.astro
@@ -92,9 +92,9 @@ function getAlertIcon(type) {
 }
 ---
 
-<div class="bg-white rounded-lg shadow p-6">
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
   <div class="flex justify-between items-center mb-6">
-    <h3 class="text-lg font-semibold text-gray-800">System Alerts</h3>
+    <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100">System Alerts</h3>
     <a href="#" class="text-sm text-blue-600 hover:text-blue-800">View all</a>
   </div>
   

--- a/src/components/DarkModeToggle.astro
+++ b/src/components/DarkModeToggle.astro
@@ -1,0 +1,29 @@
+---
+const { label = 'Dark Mode' } = Astro.props;
+---
+<div class="flex items-center" id="dark-toggle">
+  <span class="mr-2 text-sm">{label}</span>
+  <label class="inline-flex items-center cursor-pointer relative">
+    <input type="checkbox" id="dark-mode-input" class="sr-only peer">
+    <div class="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+  </label>
+</div>
+<script>
+  document.addEventListener('astro:page-load', () => {
+    const html = document.documentElement;
+    const input = document.getElementById('dark-mode-input');
+    if (localStorage.theme === 'dark') {
+      html.classList.add('dark');
+      input.checked = true;
+    }
+    input.addEventListener('change', () => {
+      if (input.checked) {
+        html.classList.add('dark');
+        localStorage.theme = 'dark';
+      } else {
+        html.classList.remove('dark');
+        localStorage.theme = 'light';
+      }
+    });
+  });
+</script>

--- a/src/components/DeploymentTable.astro
+++ b/src/components/DeploymentTable.astro
@@ -67,9 +67,9 @@ function getStatusBadge(status) {
 }
 ---
 
-<div class="bg-white rounded-lg shadow overflow-hidden">
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
   <div class="p-6">
-    <h3 class="text-lg font-semibold text-gray-800 mb-4">Recent Deployments</h3>
+    <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-4">Recent Deployments</h3>
   </div>
   
   <div class="overflow-x-auto">
@@ -84,30 +84,30 @@ function getStatusBadge(status) {
           <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
         </tr>
       </thead>
-      <tbody class="bg-white divide-y divide-gray-200">
+      <tbody class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
         {deployments.map((deployment) => (
-          <tr class="hover:bg-gray-50 transition-colors duration-150">
+          <tr class="hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors duration-150">
             <td class="px-6 py-4 whitespace-nowrap">
-              <div class="text-sm font-medium text-gray-900">{deployment.name}</div>
-              <div class="text-sm text-gray-500">{deployment.id}</div>
+              <div class="text-sm font-medium text-gray-900 dark:text-gray-100">{deployment.name}</div>
+              <div class="text-sm text-gray-500 dark:text-gray-400">{deployment.id}</div>
             </td>
             <td class="px-6 py-4 whitespace-nowrap">
-              <div class="text-sm text-gray-900">{deployment.environment}</div>
+              <div class="text-sm text-gray-900 dark:text-gray-100">{deployment.environment}</div>
             </td>
             <td class="px-6 py-4 whitespace-nowrap">
               <span class={`px-2 inline-flex text-xs leading-5 font-semibold rounded-full ${getStatusBadge(deployment.status)}`}>
                 {deployment.status}
               </span>
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
               {formatDate(deployment.timestamp)}
             </td>
-            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 dark:text-gray-400">
               {deployment.author}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
               <button class="text-indigo-600 hover:text-indigo-900 mr-2">View</button>
-              <button class="text-gray-600 hover:text-gray-900">Logs</button>
+              <button class="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white">Logs</button>
             </td>
           </tr>
         ))}

--- a/src/components/LineChart.astro
+++ b/src/components/LineChart.astro
@@ -2,9 +2,9 @@
 const { title, caption } = Astro.props;
 ---
 
-<div class="bg-white rounded-lg shadow p-6">
-  <h3 class="text-lg font-semibold text-gray-800 mb-2">{title}</h3>
-  <p class="text-sm text-gray-500 mb-4">{caption}</p>
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+  <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">{title}</h3>
+  <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{caption}</p>
   
   <!-- Simple chart implementation with HTML/CSS only -->
   <div class="relative h-64">

--- a/src/components/ResourceTimeline.astro
+++ b/src/components/ResourceTimeline.astro
@@ -54,9 +54,9 @@ function getStatusColor(status) {
 }
 ---
 
-<div class="bg-white rounded-lg shadow p-6">
-  <h3 class="text-lg font-semibold text-gray-800 mb-2">Resource Usage Timeline</h3>
-  <p class="text-sm text-gray-500 mb-6">System resource usage throughout the day</p>
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+  <h3 class="text-lg font-semibold text-gray-800 dark:text-gray-100 mb-2">Resource Usage Timeline</h3>
+  <p class="text-sm text-gray-500 dark:text-gray-400 mb-6">System resource usage throughout the day</p>
   
   <!-- Timeline container -->
   <div class="relative">

--- a/src/components/ServerStatusCard.astro
+++ b/src/components/ServerStatusCard.astro
@@ -1,0 +1,33 @@
+---
+const { name = 'Server', cpu = 40, memory = 60, status = 'online' } = Astro.props;
+---
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-4">
+  <div class="flex items-center justify-between mb-2">
+    <h4 class="font-semibold text-gray-800 dark:text-gray-100">{name}</h4>
+    <span class="text-xs px-2 py-1 rounded-full"
+          class:list={[
+            status === 'online' ? 'bg-green-100 text-green-800 dark:bg-green-600 dark:text-white' : '',
+            status === 'offline' ? 'bg-red-100 text-red-800 dark:bg-red-600 dark:text-white' : '',
+          ]}>{status}</span>
+  </div>
+  <div class="space-y-2">
+    <div>
+      <div class="flex justify-between text-sm text-gray-600 dark:text-gray-400">
+        <span>CPU</span>
+        <span>{cpu}%</span>
+      </div>
+      <div class="w-full bg-gray-200 dark:bg-gray-700 h-2 rounded">
+        <div class="bg-blue-500 h-2 rounded" style={`width: ${cpu}%`}></div>
+      </div>
+    </div>
+    <div>
+      <div class="flex justify-between text-sm text-gray-600 dark:text-gray-400">
+        <span>Memory</span>
+        <span>{memory}%</span>
+      </div>
+      <div class="w-full bg-gray-200 dark:bg-gray-700 h-2 rounded">
+        <div class="bg-purple-500 h-2 rounded" style={`width: ${memory}%`}></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/components/StatsCard.astro
+++ b/src/components/StatsCard.astro
@@ -13,7 +13,7 @@ const colorVariants = {
 const bgColor = colorVariants[color] || colorVariants.blue;
 ---
 
-<div class="bg-white rounded-lg shadow p-6 transform transition-transform duration-200 hover:scale-105">
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6 transform transition-transform duration-200 hover:scale-105">
   <div class="flex items-center">
     <div class={`${bgColor} rounded-lg p-3`}>
       <span class="text-white">
@@ -21,8 +21,8 @@ const bgColor = colorVariants[color] || colorVariants.blue;
       </span>
     </div>
     <div class="ml-4">
-      <h3 class="text-gray-500 text-sm font-medium">{title}</h3>
-      <p class="text-2xl font-semibold text-gray-800">{value}</p>
+      <h3 class="text-gray-500 dark:text-gray-400 text-sm font-medium">{title}</h3>
+      <p class="text-2xl font-semibold text-gray-800 dark:text-gray-100">{value}</p>
     </div>
   </div>
 </div>

--- a/src/layouts/DashboardLayout.astro
+++ b/src/layouts/DashboardLayout.astro
@@ -3,7 +3,7 @@ import Layout from './Layout.astro';
 ---
 
 <Layout>
-  <div class="flex h-screen bg-gray-100">
+  <div class="flex h-screen bg-gray-100 dark:bg-gray-900">
     <!-- Sidebar -->
     <aside class="w-64 bg-slate-800 text-white p-4">
       <div class="flex items-center mb-8">
@@ -63,7 +63,7 @@ import Layout from './Layout.astro';
     </aside>
 
     <!-- Main Content -->
-    <main class="flex-1 p-6 overflow-auto">
+    <main class="flex-1 p-6 overflow-auto text-gray-900 dark:text-gray-100">
       <slot />
     </main>
   </div>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="scroll-smooth">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width" />

--- a/src/pages/advanced.astro
+++ b/src/pages/advanced.astro
@@ -1,0 +1,29 @@
+---
+import DashboardLayout from '../layouts/DashboardLayout.astro';
+import StatsCard from '../components/StatsCard.astro';
+import ServerStatusCard from '../components/ServerStatusCard.astro';
+import DarkModeToggle from '../components/DarkModeToggle.astro';
+import "../styles/global.css";
+---
+<DashboardLayout>
+  <div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold text-gray-800 dark:text-gray-100">Advanced Dashboard</h1>
+    <DarkModeToggle />
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-4 gap-6 mb-6">
+    <StatsCard title="Servers" value="8" color="blue" icon='<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5h18M3 12h18M3 19h18" /></svg>' />
+    <StatsCard title="Incidents" value="2" color="red" icon='<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>' />
+    <StatsCard title="Users" value="120" color="green" icon='<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 20h5v-2a4 4 0 00-3-3.87M9 20H4v-2a4 4 0 013-3.87m7-9.13a4 4 0 11-8 0 4 4 0 018 0zm6 4v1a3 3 0 01-3 3h-1.28" /></svg>' />
+    <StatsCard title="Alerts" value="5" color="purple" icon='<svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M12 2a10 10 0 1010 10A10 10 0 0012 2z" /></svg>' />
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+    <ServerStatusCard name="Web-01" cpu={55} memory={70} status="online" />
+    <ServerStatusCard name="Web-02" cpu={35} memory={40} status="online" />
+    <ServerStatusCard name="DB-01" cpu={80} memory={90} status="offline" />
+    <ServerStatusCard name="Cache-01" cpu={25} memory={30} status="online" />
+    <ServerStatusCard name="Queue-01" cpu={45} memory={50} status="online" />
+    <ServerStatusCard name="Worker-01" cpu={60} memory={65} status="online" />
+  </div>
+</DashboardLayout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,7 @@ import ResourceTimeline from '../components/ResourceTimeline.astro';
 import NotificationBell from '../components/NotificationBell.astro';
 import NotificationBellTailwind from '../components/NotificationBellTailwind.astro';
 import ToggleSwitch from '../components/ToggleSwitch.astro';
+import DarkModeToggle from '../components/DarkModeToggle.astro';
 import "../styles/global.css";
 ---
 
@@ -48,7 +49,7 @@ import "../styles/global.css";
   <div class="bg-white rounded-lg shadow p-6 mb-6">
     <h3 class="text-lg font-semibold text-gray-800 mb-4">Tailwind Live Demo</h3>
     <div class="flex flex-col gap-4">
-      <ToggleSwitch label="Dark mode" />
+      <DarkModeToggle />
       <ToggleSwitch label="Auto-refresh" enabled={true} enabledColor="bg-green-600" />
       <ToggleSwitch label="Notifications" enabledColor="bg-purple-600" />
     </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,1 +1,9 @@
-@import "tailwindcss";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  body {
+    @apply bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: 'class',
   content: ['./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}'],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary
- add PostCSS config with ignoreFiles
- enable dark mode in Tailwind
- implement global dark theme styles
- create DarkModeToggle component and server status card
- create new `advanced` dashboard page
- integrate dark mode toggle on existing dashboard
- update several components for dark styling
- document new features in `TAILWIND-DEMO.md`

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6865f55c5328832989455ec0ddfcf163